### PR TITLE
CRUD Operations for Comments

### DIFF
--- a/clr-api/Controllers/CommentController.cs
+++ b/clr-api/Controllers/CommentController.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.InteropServices;
+using clr_api.Models;
+using clr_api.Services;
+using Microsoft.AspNetCore.Mvc;
+using ThirdParty.Json.LitJson;
+
+namespace clr_api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CommentController(CommentService commentService, UsersService usersService) : ControllerBase
+{
+    public class CommentUpdateData
+    {
+        [JsonProperty]
+        public string id { get; set; }
+        [JsonProperty]
+        public string newBody { get; set; }
+    }
+    
+    [HttpGet("{id:length(24)}")]
+    public async Task<List<Comment>> Get(string id) =>
+        await commentService.GetCommentsOnAsync(id);
+
+    [HttpPost]
+    public async Task<IActionResult> Post(Comment newComment)
+    {
+        var user = await usersService.GetByUsername(newComment.Author);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        await commentService.CreateAsync(newComment);
+        return Ok();
+    }
+
+    [HttpPatch]
+    public async Task Patch([FromBody] CommentUpdateData commentUpdateData) =>
+        await commentService.UpdateAsync(commentUpdateData.id, commentUpdateData.newBody);
+
+    [HttpDelete("{id:length(24)}")]
+    public async Task Delete(string id) =>
+        await commentService.RemoveAsync(id);
+}

--- a/clr-api/Models/ClrApiDatabaseSettings.cs
+++ b/clr-api/Models/ClrApiDatabaseSettings.cs
@@ -15,4 +15,6 @@ public class ClrApiDatabaseSettings
     public string ProblemCollectionName { get; set; } = null!;
 
     public string PullRequestCollectionName { get; set; } = null!;
+
+    public string CommentCollectionName { get; set; } = null!;
 }

--- a/clr-api/Models/Comment.cs
+++ b/clr-api/Models/Comment.cs
@@ -1,0 +1,25 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace clr_api.Models;
+
+public class Comment
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string? Id { get; set; } = null!;
+    
+    [BsonRepresentation(BsonType.ObjectId)]
+    [BsonElement("replyTo")]
+    public string? ReplyTo { get; set; }
+    
+    [BsonRepresentation(BsonType.ObjectId)]
+    [BsonElement("commentOn")]
+    public string CommentOn { get; set; } = null!;
+
+    [BsonElement("author")]
+    public string Author { get; set; } = null!;
+
+    [BsonElement("body")]
+    public string Body { get; set; } = null!;
+}

--- a/clr-api/Program.cs
+++ b/clr-api/Program.cs
@@ -22,6 +22,7 @@ builder.Services.AddSingleton<ClassService>();
 builder.Services.AddSingleton<CLRSService>();
 builder.Services.AddSingleton<ProblemService>();
 builder.Services.AddSingleton<PullRequestService>();
+builder.Services.AddSingleton<CommentService>();
 builder.Services.AddControllers();
 
 // Add services to the container.

--- a/clr-api/Services/CommentService.cs
+++ b/clr-api/Services/CommentService.cs
@@ -1,0 +1,38 @@
+﻿using clr_api.Models;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace clr_api.Services;
+
+public class CommentService
+{
+    private readonly IMongoCollection<Comment> _commentCollection;
+
+    public CommentService(
+        IOptions<ClrApiDatabaseSettings> clrApiDatabaseSettings)
+    {
+        var mongoClient = new MongoClient(
+            clrApiDatabaseSettings.Value.ConnectionString);
+
+        var mongoDatabase = mongoClient.GetDatabase(
+            clrApiDatabaseSettings.Value.DatabaseName);
+
+        _commentCollection = mongoDatabase.GetCollection<Comment>(
+            clrApiDatabaseSettings.Value.CommentCollectionName);
+    }
+
+    public async Task<List<Comment>> GetCommentsOnAsync(string id) =>
+        await _commentCollection.Find(x => x.CommentOn == id).ToListAsync();
+
+    public async Task CreateAsync(Comment newComment) =>
+        await _commentCollection.InsertOneAsync(newComment);
+    
+    public async Task UpdateAsync(string id, string newBody) {
+        var filter = Builders<Comment>.Filter.Eq(x => x.Id, id);
+        var update = Builders<Comment>.Update.Set(x => x.Body, newBody);
+        await _commentCollection.FindOneAndUpdateAsync(filter, update);
+    }
+
+    public async Task RemoveAsync(string id) =>
+        await _commentCollection.DeleteOneAsync(x => x.Id == id);
+}

--- a/clr-api/appsettings.json
+++ b/clr-api/appsettings.json
@@ -6,7 +6,8 @@
     "ClassCollectionName": "Classes",
     "CLRSCollectionName": "CLRS",
     "ProblemCollectionName": "Problems",
-    "PullRequestCollectionName": "PullRequests"
+    "PullRequestCollectionName": "PullRequests",
+    "CommentCollectionName": "Comments"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Closes #28 
* Added 4 routes implementing basic comment functionality on backend
  * Get by "commentOn" (what the comment was posted on, can be PR, problem, etc.)
  * Create comment
  * Update comment text
  * Delete comment