### PR TITLE
Feature: Improve Problem Logic

### DIFF
--- a/clr-api/Controllers/CommentController.cs
+++ b/clr-api/Controllers/CommentController.cs
@@ -18,9 +18,9 @@ public class CommentController(CommentService commentService, UsersService users
         public string newBody { get; set; }
     }
     
-    [HttpGet("{id:length(24)}")]
-    public async Task<List<Comment>> Get(string id) =>
-        await commentService.GetCommentsOnAsync(id);
+    [HttpGet("{uuid}")]
+    public async Task<List<Comment>> Get(string uuid) =>
+        await commentService.GetCommentsOnAsync(uuid);
     
     [HttpGet("{id:length(24)}/replies")]
     public async Task<List<Comment>> GetReplies(string id) =>

--- a/clr-api/Controllers/PullRequestController.cs
+++ b/clr-api/Controllers/PullRequestController.cs
@@ -15,9 +15,9 @@ public class PullRequestController(PullRequestService pullRequestService, UsersS
         return pullRequest == null ? NotFound() : pullRequest;
     }
 
-    [HttpGet("problem/{problemId:length(24)}")]
-    public async Task<ActionResult<List<PullRequest>>> GetByProblem(string problemId) =>
-        await pullRequestService.GetByProblemAsync(problemId);
+    [HttpGet("problem/{problemUuid}")]
+    public async Task<ActionResult<List<PullRequest>>> GetByProblem(string problemUuid) =>
+        await pullRequestService.GetByProblemAsync(problemUuid);
     
     [HttpPost]
     public async Task<ActionResult<PullRequest>> Post(PullRequest newPullRequest)

--- a/clr-api/Models/Comment.cs
+++ b/clr-api/Models/Comment.cs
@@ -13,7 +13,6 @@ public class Comment
     [BsonElement("replyTo")]
     public string? ReplyTo { get; set; }
     
-    [BsonRepresentation(BsonType.ObjectId)]
     [BsonElement("commentOn")]
     public string CommentOn { get; set; } = null!;
 

--- a/clr-api/Models/Problem.cs
+++ b/clr-api/Models/Problem.cs
@@ -2,6 +2,8 @@
 using System.Text.Json.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using shortid;
+using shortid.Configuration;
 
 namespace clr_api.Models;
 
@@ -35,9 +37,8 @@ public class Problem
     [BsonRepresentation(BsonType.ObjectId)]
     public string? Id { get; set; }
 
-    [BsonRepresentation(BsonType.ObjectId)]
-    [BsonElement("source")]
-    public string? Source { get; set; }
+    [BsonElement("uuid")] 
+    public string Uuid { get; init; } = ShortId.Generate(new GenerationOptions(useSpecialCharacters: false, useNumbers: true));
 
     [BsonElement("status")]
     public ProblemStatus Status { get; set; } = ProblemStatus.Review;

--- a/clr-api/Models/PullRequest.cs
+++ b/clr-api/Models/PullRequest.cs
@@ -9,7 +9,7 @@ public class PullRequest
     [BsonRepresentation(BsonType.ObjectId)]
     public string? Id { get; set; }
 
-    [BsonElement("problemId")]
+    [BsonElement("problemUuid")]
     public string ProblemUuid { get; set; }
 
     [BsonElement("upvoters")]

--- a/clr-api/Models/PullRequest.cs
+++ b/clr-api/Models/PullRequest.cs
@@ -8,10 +8,9 @@ public class PullRequest
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
     public string? Id { get; set; }
-    
-    [BsonRepresentation(BsonType.ObjectId)]
+
     [BsonElement("problemId")]
-    public string? ProblemId { get; set; }
+    public string ProblemUuid { get; set; }
 
     [BsonElement("upvoters")]
     public List<string> Upvoters { get; set; } = new();

--- a/clr-api/Services/CommentService.cs
+++ b/clr-api/Services/CommentService.cs
@@ -24,8 +24,8 @@ public class CommentService
     public async Task<Comment?> GetByIdAsync(string id) =>
         await _commentCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
     
-    public async Task<List<Comment>> GetCommentsOnAsync(string id) =>
-        await _commentCollection.Find(x => x.CommentOn == id).ToListAsync();
+    public async Task<List<Comment>> GetCommentsOnAsync(string uuid) =>
+        await _commentCollection.Find(x => x.CommentOn == uuid).ToListAsync();
 
     public async Task<List<Comment>> GetRepliesOnAsync(string commentId) =>
         await _commentCollection.Find(x => x.ReplyTo == commentId).ToListAsync();

--- a/clr-api/Services/PullRequestService.cs
+++ b/clr-api/Services/PullRequestService.cs
@@ -24,15 +24,12 @@ public class PullRequestService
         _problemService = problemService;
         _usersService = usersService;
     }
-
-    public async Task<List<PullRequest>> GetAsync() =>
-        await _pullRequestCollection.Find(_ => true).ToListAsync();
     
     public async Task<PullRequest?> GetAsync(string id) =>
         await _pullRequestCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
     
-    public async Task<List<PullRequest>> GetByProblemAsync(string id) =>
-        await _pullRequestCollection.Find(x => x.ProblemId == id).ToListAsync();
+    public async Task<List<PullRequest>> GetByProblemAsync(string uuid) =>
+        await _pullRequestCollection.Find(x => x.ProblemUuid == uuid).ToListAsync();
 
     /**
      * Create a pull request if user is a student, make the edit immediately if instructor
@@ -41,15 +38,11 @@ public class PullRequestService
     public async Task<Boolean> CreateAsync(PullRequest newPullRequest)
     {
         var author = await _usersService.GetByUsername(newPullRequest.Author);
-        var problem = await _problemService.GetLatest(newPullRequest.ProblemId ?? "");
+        var problem = await _problemService.GetLatest(newPullRequest.ProblemUuid ?? "");
         if (author is not null && problem is not null &&
             _usersService.RoleInClass(author, problem.Class) == UserRole.Instructor)
         {
-            var result = await _problemService.EditSolution(problem.Id ?? "", newPullRequest.Body, newPullRequest.Author);
-            if (result is not null)
-            {
-                await MoveToNewProblem(problem.Id ?? "", result);
-            }
+            await _problemService.EditSolution(problem.Uuid, newPullRequest.Body, newPullRequest.Author);
             return false;
         }
         await _pullRequestCollection.InsertOneAsync(newPullRequest);
@@ -73,7 +66,7 @@ public class PullRequestService
         {
             Body = pullRequest.Body,
             Id = pullRequest.Id,
-            ProblemId = pullRequest.ProblemId,
+            ProblemUuid = pullRequest.ProblemUuid,
             Author = pullRequest.Author,
             Upvoters = pullRequest.Upvoters
         };
@@ -91,8 +84,8 @@ public class PullRequestService
 
     public async Task MoveToNewProblem(string oldProblemId, string newProblemId)
     {
-        var filter = Builders<PullRequest>.Filter.Eq(x => x.ProblemId, oldProblemId);
-        var updateProblemId = Builders<PullRequest>.Update.Set(x => x.ProblemId, newProblemId);
+        var filter = Builders<PullRequest>.Filter.Eq(x => x.ProblemUuid, oldProblemId);
+        var updateProblemId = Builders<PullRequest>.Update.Set(x => x.ProblemUuid, newProblemId);
         var updateUpvoters = Builders<PullRequest>.Update.Set(x => x.Upvoters, new());
         var update = Builders<PullRequest>.Update.Combine(updateProblemId, updateUpvoters);
             
@@ -102,15 +95,8 @@ public class PullRequestService
     public async Task MergeAsync(PullRequest pullRequest)
     {
         // Update Problem with the PR's solution
-        var result = await _problemService.EditSolution(pullRequest.ProblemId, pullRequest.Body, pullRequest.Author);
-
-        if (result is not null)
-        {
-            await MoveToNewProblem(pullRequest.ProblemId, result);
-        }
-        
-        // Delete the PR
-        await RemoveAsync(pullRequest.Id);
+        await _problemService.EditSolution(pullRequest.ProblemUuid, pullRequest.Body, pullRequest.Author);
+        await RemoveAsync(pullRequest.Id ?? "");
     }
 
     public async Task UpdateBodyAsync(PullRequest pullRequest, string newBody)
@@ -120,11 +106,11 @@ public class PullRequestService
             Body = newBody,
             Author = pullRequest.Author,
             Id = pullRequest.Id,
-            ProblemId = pullRequest.ProblemId,
+            ProblemUuid = pullRequest.ProblemUuid,
             // We reset upvoters when the author updates the solution
             Upvoters = new()
         };
-        await UpdateAsync(pullRequest.Id, updatedPullRequest);
+        await UpdateAsync(pullRequest.Id ?? "", updatedPullRequest);
     }
 }
     

--- a/clr-api/clr-api.csproj
+++ b/clr-api/clr-api.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+    <PackageReference Include="shortid" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/clr-us/src/App.tsx
+++ b/clr-us/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
                   />
                   <Route
                     key={value}
-                    path={`/:id/${RouteList.Learn}/${value}/:problemId`}
+                    path={`/:id/${RouteList.Learn}/${value}/:problemUuid`}
                     element={<ViewProblem />}
                   />
                 </>

--- a/clr-us/src/components/course-page/comments/comment-card.tsx
+++ b/clr-us/src/components/course-page/comments/comment-card.tsx
@@ -53,10 +53,10 @@ export const CommentCard: React.FC<{
   body: string
   id: string
   numReplies: number
-  problemId: string
+  problemUuid: string
   handleDelete: (commentId: string) => Promise<void>
   fetchComments: () => Promise<void>
-}> = ({ author, body, id, handleDelete, numReplies, problemId, fetchComments }) => {
+}> = ({ author, body, id, handleDelete, numReplies, problemUuid, fetchComments }) => {
   const { user } = useAuth()
   const courseID = useCurrentCourse()
 
@@ -87,7 +87,11 @@ export const CommentCard: React.FC<{
           <Typography fontWeight={600}>{author}</Typography>
           <Typography>{parse(body)}</Typography>
 
-          <ReplyButton originalCommentId={id} problemId={problemId} fetchComments={fetchComments} />
+          <ReplyButton
+            originalCommentId={id}
+            problemUuid={problemUuid}
+            fetchComments={fetchComments}
+          />
           {numReplies > 0 && (
             <RepliesAccordion
               numReplies={numReplies}

--- a/clr-us/src/components/course-page/comments/comment.service.ts
+++ b/clr-us/src/components/course-page/comments/comment.service.ts
@@ -3,15 +3,15 @@ import { axios } from '@/components/services/axios'
 import { IPostComment, Comment } from './type'
 
 class CommentService {
-  getComments = (problemId: string) =>
+  getComments = (problemUuid: string) =>
     axios
-      .get(`/Comment/${problemId}`)
+      .get(`/Comment/${problemUuid}`)
       .then((res) => res.data.filter((el: Comment) => !el.replyTo))
       .catch((err) => err)
 
-  getReplies = (commentId: string) =>
+  getReplies = (commentUuid: string) =>
     axios
-      .get(`/Comment/${commentId}/replies`)
+      .get(`/Comment/${commentUuid}/replies`)
       .then((res) => res.data)
       .catch((err) => err)
 
@@ -21,9 +21,9 @@ class CommentService {
       .then()
       .catch((err) => err)
 
-  deleteComment = (commentId: string) =>
+  deleteComment = (commentUuid: string) =>
     axios
-      .delete(`/Comment/${commentId}`)
+      .delete(`/Comment/${commentUuid}`)
       .then()
       .catch((err) => err)
 }

--- a/clr-us/src/components/course-page/comments/problem-comments.tsx
+++ b/clr-us/src/components/course-page/comments/problem-comments.tsx
@@ -12,7 +12,7 @@ import { useNotification } from '@/hooks/useNotification'
 
 import { Comment, IPostComment } from './type'
 
-export const ProblemComments = (props: { problemId: string }) => {
+export const ProblemComments = (props: { problemUuid: string }) => {
   const [comments, setComments] = useState<Comment[]>([])
   const [isEditing, setIsEditing] = useState(false)
 
@@ -23,19 +23,22 @@ export const ProblemComments = (props: { problemId: string }) => {
     author: user?.username || '',
     body: '',
     replyTo: null,
-    commentOn: props.problemId,
+    commentOn: props.problemUuid,
   } as IPostComment)
 
   const fetchComments = useCallback(
-    () => commentService.getComments(props.problemId).then((res) => setComments(res)),
-    [props.problemId]
+    () =>
+      commentService.getComments(props.problemUuid).then((res) => {
+        setComments(res)
+      }),
+    [props.problemUuid]
   )
 
   useEffect(() => {
-    if (props.problemId) {
+    if (props.problemUuid) {
       fetchComments().then()
     }
-  }, [fetchComments, props.problemId])
+  }, [fetchComments, props.problemUuid])
 
   const handleDeleteComment = useCallback(
     async (commentId: string) => {
@@ -56,7 +59,7 @@ export const ProblemComments = (props: { problemId: string }) => {
       await commentService
         .postComment({
           ...values,
-          commentOn: props.problemId,
+          commentOn: props.problemUuid,
           numReplies: 0,
         })
         .then(() => {
@@ -66,7 +69,7 @@ export const ProblemComments = (props: { problemId: string }) => {
           fetchComments().then()
         })
     },
-    [fetchComments, props.problemId]
+    [fetchComments, props.problemUuid]
   )
 
   const validationSchema = Yup.object().shape({
@@ -135,7 +138,7 @@ export const ProblemComments = (props: { problemId: string }) => {
               <CommentCard
                 {...comment}
                 handleDelete={handleDeleteComment}
-                problemId={comment.commentOn}
+                problemUuid={comment.commentOn}
                 fetchComments={fetchComments}
               />
               {index < comments.length - 1 && <Divider />}

--- a/clr-us/src/components/course-page/comments/replies-accordion.tsx
+++ b/clr-us/src/components/course-page/comments/replies-accordion.tsx
@@ -80,7 +80,7 @@ export const RepliesAccordion: React.FC<{
                 <CommentCard
                   {...comment}
                   handleDelete={handleDeleteComment}
-                  problemId={comment.commentOn}
+                  problemUuid={comment.commentOn}
                   fetchComments={fetchReplies}
                 />
                 {index < replies.length - 1 && <Divider />}

--- a/clr-us/src/components/course-page/comments/reply-button.tsx
+++ b/clr-us/src/components/course-page/comments/reply-button.tsx
@@ -11,9 +11,9 @@ import { IPostComment } from './type'
 
 export const ReplyButton: React.FC<{
   originalCommentId: string
-  problemId: string
+  problemUuid: string
   fetchComments: () => Promise<void>
-}> = ({ originalCommentId, problemId, fetchComments }) => {
+}> = ({ originalCommentId, problemUuid, fetchComments }) => {
   const [isReplying, setIsReplying] = useState(false)
 
   const { user } = useAuth()
@@ -22,7 +22,7 @@ export const ReplyButton: React.FC<{
     author: user?.username || '',
     body: '',
     replyTo: originalCommentId,
-    commentOn: problemId,
+    commentOn: problemUuid,
   } as IPostComment)
 
   const validationSchema = Yup.object().shape({

--- a/clr-us/src/components/course-page/endorsed-problem.tsx
+++ b/clr-us/src/components/course-page/endorsed-problem.tsx
@@ -37,7 +37,7 @@ const SolutionEditor = (props: {
   const handleSubmit = useCallback(
     async (values: IPREdit) => {
       await pullRequestService
-        .postPullRequest(props.problem?.id ?? '', values.solution, values.author)
+        .postPullRequest(props.problem?.uuid ?? '', values.solution, values.author)
         .then(async () => {
           props.closeEditor()
           props.forceRefresh()
@@ -137,7 +137,7 @@ export const EndorsedProblem = (props: {
       {role === UserRoles.Instructor && (
         <Grid>
           <Button
-            onClick={problemService.endorseProblem(navigate, props.problem?.id ?? '')}
+            onClick={problemService.endorseProblem(navigate, props.problem?.uuid ?? '')}
             variant={'outlined'}
             sx={{ mr: 1, mt: 2 }}
             color="error"

--- a/clr-us/src/components/course-page/post-problem.tsx
+++ b/clr-us/src/components/course-page/post-problem.tsx
@@ -42,7 +42,6 @@ export const PostProblem: React.FC = () => {
     if (isCLRSProblem) {
       // TODO: Make this dynamic, problem to be selected in a dropdown
       postService.getCLRSProblem(15, 1).then((res) => {
-        console.log('i happen')
         setInitialValues({
           ...initialValues,
           ...res,

--- a/clr-us/src/components/course-page/posted-problem.tsx
+++ b/clr-us/src/components/course-page/posted-problem.tsx
@@ -38,10 +38,10 @@ const SolutionEditor = (props: {
   const handleSubmit = useCallback(
     async (values: IPREdit) => {
       await pullRequestService
-        .postPullRequest(props.problem?.id ?? '', values.solution, values.author)
+        .postPullRequest(props.problem?.uuid ?? '', values.solution, values.author)
         .then(async () => {
           props.closeEditor()
-          await pullRequestService.getPullRequests(props.problem?.id ?? '', props.setPr)
+          await pullRequestService.getPullRequests(props.problem?.uuid ?? '', props.setPr)
           notify({
             message: 'Success! Your suggestion has been posted and is up for review.',
             severity: 'success',
@@ -95,7 +95,7 @@ export const PostedProblem = (props: { problemType: ProblemType; problem?: Probl
 
   useEffect(() => {
     if (props.problem) {
-      pullRequestService.getPullRequests(props.problem.id, setPrs)
+      pullRequestService.getPullRequests(props.problem.uuid, setPrs)
     }
   }, [props.problem])
 
@@ -138,7 +138,7 @@ export const PostedProblem = (props: { problemType: ProblemType; problem?: Probl
       </Grid>
       <Grid>
         <Button
-          onClick={problemService.endorseProblem(navigate, props.problem?.id ?? '')}
+          onClick={problemService.endorseProblem(navigate, props.problem?.uuid ?? '')}
           variant={'contained'}
           sx={{ mr: 1, mt: 2 }}
         >

--- a/clr-us/src/components/course-page/posted-problem.tsx
+++ b/clr-us/src/components/course-page/posted-problem.tsx
@@ -158,7 +158,7 @@ export const PostedProblem = (props: { problemType: ProblemType; problem?: Probl
           </Button>
         </Grid>
         <Grid container mt={2}>
-          <ProblemComments problemId={props.problem?.id ?? ''} />
+          <ProblemComments problemUuid={props.problem?.uuid ?? ''} />
         </Grid>
       </Grid>
     </Grid>

--- a/clr-us/src/components/course-page/pr-modal.tsx
+++ b/clr-us/src/components/course-page/pr-modal.tsx
@@ -46,16 +46,16 @@ const PrCard = (props: {
     }
     pullRequestService
       .upvote(props.pr.id, username)
-      .then(() => pullRequestService.getPullRequests(props.pr.problemId, props.setPr))
+      .then(() => pullRequestService.getPullRequests(props.pr.problemUuid, props.setPr))
   }
   const handleMerge = () => {
     const goToNewProblem = (problem: Problem) => {
-      navigate(`./../${problem.id}`)
+      navigate(`./../${problem.uuid}`)
       props.close()
     }
     pullRequestService
       .merge(props.pr.id)
-      .then(() => problemService.getLatest(props.pr.problemId, goToNewProblem))
+      .then(() => problemService.getLatest(props.pr.problemUuid, goToNewProblem))
   }
 
   return (

--- a/clr-us/src/components/course-page/problem-card.tsx
+++ b/clr-us/src/components/course-page/problem-card.tsx
@@ -22,7 +22,7 @@ export const ProblemCard = (props: { problem: Problem }) => {
       <Card sx={{ p: 3, width: '100%', height: 200 }}>
         <Stack direction={'row'} justifyContent={'space-between'}>
           <Link
-            to={props.problem.id}
+            to={props.problem.uuid}
             style={{ textDecoration: 'none', color: theme.palette.primary.main }}
           >
             <Typography variant="h6">{props.problem.title}</Typography>

--- a/clr-us/src/components/course-page/problem.service.ts
+++ b/clr-us/src/components/course-page/problem.service.ts
@@ -26,33 +26,33 @@ class ProblemService {
       .catch((err) => err)
   }
 
-  getProblem = (id: string, setProblem: (problem: Problem) => void) =>
+  getProblem = (uuid: string, setProblem: (problem: Problem) => void) =>
     axios
-      .get(`/Problem/${id}`)
+      .get(`/Problem/${uuid}`)
       .then((res) => setProblem(res.data))
       .catch((err) => err)
 
-  getLatest = (id: string, setLatest: (problem: Problem) => void) =>
+  getLatest = (uuid: string, setLatest: (problem: Problem) => void) =>
     axios
-      .get(`/Problem/latest/${id}`)
+      .get(`/Problem/latest/${uuid}`)
       .then((res) => setLatest(res.data))
       .catch((err) => err)
 
-  approveProblem = (navigate: NavigateFunction, id: string) => () =>
+  approveProblem = (navigate: NavigateFunction, uuid: string) => () =>
     axios
-      .patch(`/Problem/status/${id}/${ProblemStatus.Posted}`)
+      .patch(`/Problem/status/${uuid}/${ProblemStatus.Posted}`)
       .then(() => navigate('..'))
       .catch((err) => err)
 
-  endorseProblem = (navigate: NavigateFunction, id: string) => () =>
+  endorseProblem = (navigate: NavigateFunction, uuid: string) => () =>
     axios
-      .patch(`/Problem/status/${id}/${ProblemStatus.Endorsed}`)
+      .patch(`/Problem/status/${uuid}/${ProblemStatus.Endorsed}`)
       .then(() => navigate('..'))
       .catch((err) => err)
 
-  deleteProblem = (navigate: NavigateFunction, id: string) => () =>
+  deleteProblem = (navigate: NavigateFunction, uuid: string) => () =>
     axios
-      .delete(`/Problem/${id}`)
+      .delete(`/Problem/${uuid}`)
       .then(() => navigate('..'))
       .catch((err) => err)
 }

--- a/clr-us/src/components/course-page/pullrequest.service.ts
+++ b/clr-us/src/components/course-page/pullrequest.service.ts
@@ -3,10 +3,10 @@ import { PullRequest, isPullRequest } from '@/types'
 import { axios } from '../services/axios'
 
 class PullRequestService {
-  postPullRequest = (problemId: string, body: string, author: string) => {
+  postPullRequest = (problemUuid: string, body: string, author: string) => {
     return axios
       .post('/PullRequest', {
-        problemId,
+        problemUuid,
         body,
         author,
       })
@@ -14,15 +14,15 @@ class PullRequestService {
       .catch((err) => err)
   }
 
-  getPullRequests = (problemId: string, setPrs: (prs: PullRequest[] | null) => void) =>
+  getPullRequests = (problemUuid: string, setPrs: (prs: PullRequest[] | null) => void) =>
     axios
-      .get(`/PullRequest/problem/${problemId}`)
+      .get(`/PullRequest/problem/${problemUuid}`)
       .then((res) => setPrs(res.data.filter(isPullRequest)))
       .catch((err) => err)
 
-  upvote = (problemId: string, username: string) =>
+  upvote = (prId: string, username: string) =>
     axios
-      .post(`/PullRequest/upvote?id=${problemId}&username=${username}`)
+      .post(`/PullRequest/upvote?id=${prId}&username=${username}`)
       .then()
       .catch((err) => err)
 

--- a/clr-us/src/components/course-page/review-problem.tsx
+++ b/clr-us/src/components/course-page/review-problem.tsx
@@ -79,14 +79,14 @@ export const ReviewProblem = (props: { problemType: ProblemType; problem?: Probl
         )}
         <Grid>
           <Button
-            onClick={problemService.approveProblem(navigate, props.problem?.id ?? '')}
+            onClick={problemService.approveProblem(navigate, props.problem?.uuid ?? '')}
             variant={'contained'}
             sx={{ mr: 1 }}
           >
             Accept
           </Button>
           <Button
-            onClick={problemService.deleteProblem(navigate, props.problem?.id ?? '')}
+            onClick={problemService.deleteProblem(navigate, props.problem?.uuid ?? '')}
             variant={'outlined'}
           >
             Delete

--- a/clr-us/src/components/course-page/view-problem.tsx
+++ b/clr-us/src/components/course-page/view-problem.tsx
@@ -4,7 +4,7 @@ import 'react-quill/dist/quill.snow.css'
 
 import { Sidebar } from '@/components/navbar'
 import { ProblemStatus } from '@/enum'
-import { useGetProblemId, useGetProblemType } from '@/hooks'
+import { useGetProblemUuid, useGetProblemType } from '@/hooks'
 import { Problem } from '@/types/problem'
 
 import { EndorsedProblem } from './endorsed-problem'
@@ -14,15 +14,15 @@ import { ReviewProblem } from './review-problem'
 
 export const ViewProblem: React.FC = () => {
   const problemType = useGetProblemType()
-  const problemId = useGetProblemId()
+  const problemUuid = useGetProblemUuid()
   const [problem, setProblem] = useState<Problem | undefined>(undefined)
   const [status, setStatus] = useState<ProblemStatus>(ProblemStatus.Posted)
 
-  const forceRefresh = () => problemService.getProblem(problemId, setProblem)
+  const forceRefresh = () => problemService.getProblem(problemUuid, setProblem)
 
   useEffect(() => {
-    problemService.getProblem(problemId, setProblem)
-  }, [problemId, setProblem])
+    problemService.getProblem(problemUuid, setProblem)
+  }, [problemUuid, setProblem])
 
   useEffect(() => {
     if (!problem) {

--- a/clr-us/src/hooks/index.ts
+++ b/clr-us/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export * from './useRedirectLogin'
 export * from './useCourseCheck'
 export * from './useGetProblemType'
-export * from './useGetProblemId'
+export * from './useGetProblemUuid'
 export * from './useWindowSize'

--- a/clr-us/src/hooks/useGetProblemUuid.ts
+++ b/clr-us/src/hooks/useGetProblemUuid.ts
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom'
 
-export const useGetProblemId = () => {
+export const useGetProblemUuid = () => {
   const location = useLocation()
   return location.pathname.split('/')[4]
 }

--- a/clr-us/src/types/problem.ts
+++ b/clr-us/src/types/problem.ts
@@ -2,7 +2,7 @@ export const isProblem = (problem: unknown): problem is Problem => {
   if (!problem || typeof problem !== 'object') {
     return false
   }
-  const requiredKeys = ['id', 'status', 'title', 'body', 'solution', 'type', 'author']
+  const requiredKeys = ['id', 'status', 'title', 'body', 'solution', 'type', 'author', 'uuid']
   if (requiredKeys.some((key) => !Object.hasOwn(problem, key))) {
     return false
   }
@@ -17,6 +17,7 @@ export enum ProblemStatus {
 
 export type Problem = {
   id: string
+  uuid: string
   status: ProblemStatus
   title: string
   body: string

--- a/clr-us/src/types/pullrequest.ts
+++ b/clr-us/src/types/pullrequest.ts
@@ -2,13 +2,13 @@ export const isPullRequest = (pr: unknown): pr is PullRequest => {
   if (!pr || typeof pr !== 'object') {
     return false
   }
-  const requiredKeys = ['id', 'problemId', 'upvoters', 'body', 'author']
+  const requiredKeys = ['id', 'problemUuid', 'upvoters', 'body', 'author']
   return requiredKeys.every((key) => Object.hasOwn(pr, key))
 }
 
 export type PullRequest = {
   id: string
-  problemId: string
+  problemUuid: string
   upvoters: string[]
   body: string
   author: string


### PR DESCRIPTION
The current structure of problems uses their objectid as an identifier, and source/version fields to navigate between edit histories. This causes lots of unnecessary complexity in our code. So we remove the source field and any direct reference to the objectid in the frontend under this PR, using instead a short uuid generated at random to identify problems.