### PR TITLE
Fix: Incorrectly Showing Endorse Button

### DIFF
--- a/clr-us/src/components/course-page/view-problem.tsx
+++ b/clr-us/src/components/course-page/view-problem.tsx
@@ -44,7 +44,7 @@ export const ViewProblem: React.FC = () => {
       {status === ProblemStatus.Review ? (
         <ReviewProblem problemType={problemType} problem={problem} />
       ) : status === ProblemStatus.Posted ? (
-        <PostedProblem problemType={problemType} problem={problem} />
+        <PostedProblem problemType={problemType} problem={problem} forceRefresh={forceRefresh} />
       ) : (
         <EndorsedProblem problemType={problemType} problem={problem} forceRefresh={forceRefresh} />
       )}


### PR DESCRIPTION
Endorse button should be shown only to instructors. This PR applies that logic. Also adds fetches to get solution updates after a PR merge or a TA submits a solution.